### PR TITLE
Use prop-types package

### DIFF
--- a/package.json
+++ b/package.json
@@ -43,8 +43,9 @@
   },
   "homepage": "https://github.com/souporserious/react-fluid-container",
   "peerDependencies": {
-    "react": "0.14.x || ^15.0.0",
-    "react-dom": "0.14.x || ^15.0.0"
+    "react": "^15.5.0",
+    "react-dom": "^15.5.0",
+    "prop-types": "^15.5.0"
   },
   "dependencies": {
     "react-measure": "^1.4.2",
@@ -64,9 +65,10 @@
     "node-libs-browser": "^1.0.0",
     "node-sass": "^3.2.0",
     "postcss-loader": "^0.13.0",
-    "react": "15.3.2",
-    "react-aria": "^0.3.0",
-    "react-dom": "15.3.2",
+    "prop-types": "^15.5.0",
+    "react": "^15.5.0",
+    "react-aria": "^0.4.0",
+    "react-dom": "^15.5.0",
     "sass-loader": "^4.0.2",
     "style-loader": "^0.13.1",
     "webpack": "^1.13.2",

--- a/src/FluidContainer.jsx
+++ b/src/FluidContainer.jsx
@@ -1,4 +1,5 @@
-import React, { Component, PropTypes, Children, createElement, cloneElement } from 'react'
+import React, { Component, Children, createElement, cloneElement } from 'react'
+import PropTypes from 'prop-types'
 import { Motion, spring, presets } from 'react-motion'
 import Measure from 'react-measure'
 


### PR DESCRIPTION
React 15.5 moved PropTypes out to a separate package.

Additionally, react-aria was minimally upgraded to 0.4.0 because 0.3.0 was
pulled.