### PR TITLE
Remove reference to React.PropTypes in FluidContainer.jsx

### DIFF
--- a/src/FluidContainer.jsx
+++ b/src/FluidContainer.jsx
@@ -7,7 +7,7 @@ class FluidContainer extends Component {
   static propTypes = {
     tag: PropTypes.string,
     height: PropTypes.oneOfType([PropTypes.number, PropTypes.oneOf(['auto'])]),
-    rmConfig: React.PropTypes.objectOf(React.PropTypes.number),
+    rmConfig: PropTypes.objectOf(PropTypes.number),
     children: PropTypes.node.isRequired,
     beforeAnimation: PropTypes.func,
     afterAnimation: PropTypes.func,


### PR DESCRIPTION
Hey, it looks like there's still one reference to React.PropTypes left in this package.  