### PR TITLE
Update to React v16, React Measure v2.0.2

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -19,3 +19,6 @@ lib
 .cache
 .project
 .tmp
+tags
+tags.*
+.tern-port

--- a/example/index.jsx
+++ b/example/index.jsx
@@ -9,9 +9,6 @@ import PropTypes from 'prop-types'
 import ReactDOM, { findDOMNode } from 'react-dom'
 import {
   AriaManager,
-  AriaToggle,
-  AriaPopover,
-  AriaItem,
   AriaTabList,
   AriaTab,
   AriaPanel,

--- a/package.json
+++ b/package.json
@@ -43,13 +43,14 @@
   },
   "homepage": "https://github.com/souporserious/react-fluid-container",
   "peerDependencies": {
-    "react": "^15.5.0",
-    "react-dom": "^15.5.0",
     "prop-types": "^15.5.0"
   },
   "dependencies": {
     "prop-types": "^15.5.10",
-    "react-measure": "^1.4.2",
+    "react": "^16.0.0",
+    "react-aria": "^0.9.2",
+    "react-dom": "^16.0.0",
+    "react-measure": "^2.0.2",
     "react-motion": "^0.5.0"
   },
   "devDependencies": {
@@ -69,9 +70,6 @@
     "node-sass": "^3.2.0",
     "postcss-loader": "^0.13.0",
     "prop-types": "^15.5.0",
-    "react": "^15.5.0",
-    "react-aria": "^0.4.0",
-    "react-dom": "^15.5.0",
     "sass-loader": "^4.0.2",
     "style-loader": "^0.13.1",
     "webpack": "^1.13.2",

--- a/package.json
+++ b/package.json
@@ -43,13 +43,12 @@
   },
   "homepage": "https://github.com/souporserious/react-fluid-container",
   "peerDependencies": {
+    "react": "^16.0.0",
+    "react-dom": "^16.0.0",
     "prop-types": "^15.5.0"
   },
   "dependencies": {
     "prop-types": "^15.5.10",
-    "react": "^16.0.0",
-    "react-aria": "^0.9.2",
-    "react-dom": "^16.0.0",
     "react-measure": "^2.0.2",
     "react-motion": "^0.5.0"
   },
@@ -70,6 +69,7 @@
     "node-sass": "^3.2.0",
     "postcss-loader": "^0.13.0",
     "prop-types": "^15.5.0",
+    "react-aria": "^0.9.2",
     "sass-loader": "^4.0.2",
     "style-loader": "^0.13.1",
     "webpack": "^1.13.2",

--- a/src/FluidContainer.jsx
+++ b/src/FluidContainer.jsx
@@ -7,7 +7,7 @@ class FluidContainer extends Component {
   static propTypes = {
     tag: PropTypes.string,
     height: PropTypes.oneOfType([PropTypes.number, PropTypes.oneOf(['auto'])]),
-    rmConfig: React.PropTypes.objectOf(React.PropTypes.number),
+    rmConfig: PropTypes.objectOf(PropTypes.number),
     children: PropTypes.node.isRequired,
     beforeAnimation: PropTypes.func,
     afterAnimation: PropTypes.func,
@@ -43,7 +43,7 @@ class FluidContainer extends Component {
     }
   }
 
-  _handleMeasure = ({ height }) => {
+  _handleMeasure = ({ bounds: { height } }) => {
     // store the height so we can apply it to the element immediately
     // and avoid any element jumping
     if (height > 0) {
@@ -88,13 +88,17 @@ class FluidContainer extends Component {
     const rmHeight = height === 'auto' ? this.state.height : height
     const child = (
       <Measure
-        ref={c => (this._measureComponent = c)}
         whitelist={['height']}
-        onMeasure={this._handleMeasure}
+        onResize={args => this._handleMeasure(args)}
+        bounds
       >
-        {cloneElement(Children.only(children), { onInput: this._handleInput })}
+        {({ measureRef }) =>
+          cloneElement(Children.only(children), {
+            onInput: this._handleInput,
+            ref: node => measureRef(node),
+          })}
       </Measure>
-    )
+    );
     return (
       <Motion
         defaultStyle={{ _height: rmHeight }}

--- a/yarn.lock
+++ b/yarn.lock
@@ -1699,19 +1699,7 @@ faye-websocket@~0.11.0:
   dependencies:
     websocket-driver ">=0.5.1"
 
-fbjs@^0.8.16, fbjs@^0.8.8:
-  version "0.8.16"
-  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.16.tgz#5e67432f550dc41b572bf55847b8aca64e5337db"
-  dependencies:
-    core-js "^1.0.0"
-    isomorphic-fetch "^2.1.1"
-    loose-envify "^1.0.0"
-    object-assign "^4.1.0"
-    promise "^7.1.1"
-    setimmediate "^1.0.5"
-    ua-parser-js "^0.7.9"
-
-fbjs@^0.8.9:
+fbjs@^0.8.8, fbjs@^0.8.9:
   version "0.8.12"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.12.tgz#10b5d92f76d45575fd63a217d4ea02bea2f8ed04"
   dependencies:
@@ -2437,7 +2425,7 @@ longest@^1.0.1:
   version "1.0.1"
   resolved "https://registry.yarnpkg.com/longest/-/longest-1.0.1.tgz#30a0b2da38f73770e8294a0d22e6625ed77d0097"
 
-loose-envify@^1.0.0, loose-envify@^1.1.0, loose-envify@^1.3.1:
+loose-envify@^1.0.0, loose-envify@^1.3.1:
   version "1.3.1"
   resolved "https://registry.yarnpkg.com/loose-envify/-/loose-envify-1.3.1.tgz#d1a8ad33fa9ce0e713d65fdd0ac8b748d478c848"
   dependencies:
@@ -3231,20 +3219,12 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.10:
+prop-types@^15.5.10, prop-types@^15.5.8:
   version "15.5.10"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.10.tgz#2797dfc3126182e3a95e3dfbb2e893ddd7456154"
   dependencies:
     fbjs "^0.8.9"
     loose-envify "^1.3.1"
-
-prop-types@^15.5.8, prop-types@^15.6.0:
-  version "15.6.0"
-  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.0.tgz#ceaf083022fc46b4a35f69e13ef75aed0d639856"
-  dependencies:
-    fbjs "^0.8.16"
-    loose-envify "^1.3.1"
-    object-assign "^4.1.1"
 
 proxy-addr@~1.1.2:
   version "1.1.2"
@@ -3355,15 +3335,6 @@ react-aria@^0.9.2:
     unique-number "^2.0.1"
     upper-case-first "^1.1.2"
 
-react-dom@^16.0.0:
-  version "16.0.0"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.0.0.tgz#9cc3079c3dcd70d4c6e01b84aab2a7e34c303f58"
-  dependencies:
-    fbjs "^0.8.16"
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.0"
-
 react-measure@^2.0.2:
   version "2.0.2"
   resolved "https://registry.yarnpkg.com/react-measure/-/react-measure-2.0.2.tgz#072a9a5fafc01dfbadc1fa5fb09fc351037f636c"
@@ -3379,15 +3350,6 @@ react-motion@^0.5.0:
     performance-now "^0.2.0"
     prop-types "^15.5.8"
     raf "^3.1.0"
-
-react@^16.0.0:
-  version "16.0.0"
-  resolved "https://registry.yarnpkg.com/react/-/react-16.0.0.tgz#ce7df8f1941b036f02b2cca9dbd0cb1f0e855e2d"
-  dependencies:
-    fbjs "^0.8.16"
-    loose-envify "^1.1.0"
-    object-assign "^4.1.1"
-    prop-types "^15.6.0"
 
 read-pkg-up@^1.0.1:
   version "1.0.1"

--- a/yarn.lock
+++ b/yarn.lock
@@ -6,6 +6,13 @@ Base64@~0.2.0:
   version "0.2.1"
   resolved "https://registry.yarnpkg.com/Base64/-/Base64-0.2.1.tgz#ba3a4230708e186705065e66babdd4c35cf60028"
 
+a11y-focus-scope@^1.1.3:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/a11y-focus-scope/-/a11y-focus-scope-1.1.3.tgz#f795384d4dd40ccec1c4a160ef4d13371d015ae8"
+  dependencies:
+    focusin "^2.0.0"
+    tabbable "^1.0.0"
+
 abbrev@1:
   version "1.0.9"
   resolved "https://registry.yarnpkg.com/abbrev/-/abbrev-1.0.9.tgz#91b4792588a7738c25f35dd6f63752a2f8776135"
@@ -1692,7 +1699,19 @@ faye-websocket@~0.11.0:
   dependencies:
     websocket-driver ">=0.5.1"
 
-fbjs@^0.8.4, fbjs@^0.8.8, fbjs@^0.8.9:
+fbjs@^0.8.16, fbjs@^0.8.8:
+  version "0.8.16"
+  resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.16.tgz#5e67432f550dc41b572bf55847b8aca64e5337db"
+  dependencies:
+    core-js "^1.0.0"
+    isomorphic-fetch "^2.1.1"
+    loose-envify "^1.0.0"
+    object-assign "^4.1.0"
+    promise "^7.1.1"
+    setimmediate "^1.0.5"
+    ua-parser-js "^0.7.9"
+
+fbjs@^0.8.9:
   version "0.8.12"
   resolved "https://registry.yarnpkg.com/fbjs/-/fbjs-0.8.12.tgz#10b5d92f76d45575fd63a217d4ea02bea2f8ed04"
   dependencies:
@@ -1739,15 +1758,9 @@ flatten@^1.0.2:
   version "1.0.2"
   resolved "https://registry.yarnpkg.com/flatten/-/flatten-1.0.2.tgz#dae46a9d78fbe25292258cc1e780a41d95c03782"
 
-focus-group@^0.3.0:
-  version "0.3.1"
-  resolved "https://registry.yarnpkg.com/focus-group/-/focus-group-0.3.1.tgz#e0f32ed86b0dabdd6ffcebdf898ecb32e47fedce"
-
-focus-trap@^2.0.1:
-  version "2.1.0"
-  resolved "https://registry.yarnpkg.com/focus-trap/-/focus-trap-2.1.0.tgz#00e20dea96be9346897208860bd19136da87516a"
-  dependencies:
-    tabbable "^1.0.3"
+focusin@^2.0.0:
+  version "2.0.0"
+  resolved "https://registry.yarnpkg.com/focusin/-/focusin-2.0.0.tgz#58c01180dfb1949f03e3ddeee063739fc33b6ffc"
 
 for-in@^0.1.5:
   version "0.1.6"
@@ -2553,6 +2566,10 @@ minimist@^1.1.0, minimist@^1.1.3, minimist@^1.2.0:
   version "1.2.0"
   resolved "https://registry.yarnpkg.com/minimist/-/minimist-1.2.0.tgz#a35008b20f41383eec1fb914f4cd5df79a264284"
 
+mitt@^1.0.1:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/mitt/-/mitt-1.1.2.tgz#380e61480d6a615b660f07abb60d51e0a4e4bed6"
+
 mkdirp@0.5.x, "mkdirp@>=0.5 0", mkdirp@^0.5.0, mkdirp@^0.5.1, mkdirp@~0.5.0, mkdirp@~0.5.1:
   version "0.5.1"
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-0.5.1.tgz#30057438eac6cf7f8c4767f38648d6697d75c903"
@@ -2571,9 +2588,9 @@ negotiator@0.6.1:
   version "0.6.1"
   resolved "https://registry.yarnpkg.com/negotiator/-/negotiator-0.6.1.tgz#2b327184e8992101177b28563fb5e7102acd0ca9"
 
-no-scroll@^1.1.2:
-  version "1.1.2"
-  resolved "https://registry.yarnpkg.com/no-scroll/-/no-scroll-1.1.2.tgz#a273eb237104cb6ba8b6ed2c464deb187a756a88"
+no-scroll@^2.0.0:
+  version "2.1.0"
+  resolved "https://registry.yarnpkg.com/no-scroll/-/no-scroll-2.1.0.tgz#f8643b3ddb6a3bf94430e5ff31d26f21d082a695"
 
 node-fetch@^1.0.1:
   version "1.6.3"
@@ -2758,11 +2775,7 @@ oauth-sign@~0.8.1:
   version "0.8.2"
   resolved "https://registry.yarnpkg.com/oauth-sign/-/oauth-sign-0.8.2.tgz#46a6ab7f0aead8deae9ec0565780b7d4efeb9d43"
 
-object-assign@^4.0.1, object-assign@^4.1.0:
-  version "4.1.0"
-  resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.0.tgz#7a3b3d0e98063d43f4c03f2e8ae6cd51a86883a0"
-
-object-assign@^4.1.1:
+object-assign@^4.0.1, object-assign@^4.1.0, object-assign@^4.1.1:
   version "4.1.1"
   resolved "https://registry.yarnpkg.com/object-assign/-/object-assign-4.1.1.tgz#2109adc7965887cfc05cbbd442cac8bfbb360863"
 
@@ -3218,12 +3231,20 @@ promise@^7.1.1:
   dependencies:
     asap "~2.0.3"
 
-prop-types@^15.5.10, prop-types@^15.5.8:
+prop-types@^15.5.10:
   version "15.5.10"
   resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.5.10.tgz#2797dfc3126182e3a95e3dfbb2e893ddd7456154"
   dependencies:
     fbjs "^0.8.9"
     loose-envify "^1.3.1"
+
+prop-types@^15.5.8, prop-types@^15.6.0:
+  version "15.6.0"
+  resolved "https://registry.yarnpkg.com/prop-types/-/prop-types-15.6.0.tgz#ceaf083022fc46b4a35f69e13ef75aed0d639856"
+  dependencies:
+    fbjs "^0.8.16"
+    loose-envify "^1.3.1"
+    object-assign "^4.1.1"
 
 proxy-addr@~1.1.2:
   version "1.1.2"
@@ -3323,25 +3344,33 @@ rc@~1.1.6:
     minimist "^1.2.0"
     strip-json-comments "~1.0.4"
 
-react-aria@^0.3.0:
-  version "0.3.0"
-  resolved "https://registry.yarnpkg.com/react-aria/-/react-aria-0.3.0.tgz#594f05c30c007a8b6d54d7763fbf3477bcda93c8"
+react-aria@^0.9.2:
+  version "0.9.2"
+  resolved "https://registry.yarnpkg.com/react-aria/-/react-aria-0.9.2.tgz#eec655fc85a537c176296d80fef3cf0eb35a2c1a"
   dependencies:
-    focus-group "^0.3.0"
-    focus-trap "^2.0.1"
-    no-scroll "^1.1.2"
-    teeny-tap "^0.2.0"
+    a11y-focus-scope "^1.1.3"
+    mitt "^1.0.1"
+    no-scroll "^2.0.0"
+    scroll-into-view "^1.7.3"
+    unique-number "^2.0.1"
+    upper-case-first "^1.1.2"
 
-react-dom@15.3.2:
-  version "15.3.2"
-  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-15.3.2.tgz#c46b0aa5380d7b838e7a59c4a7beff2ed315531f"
+react-dom@^16.0.0:
+  version "16.0.0"
+  resolved "https://registry.yarnpkg.com/react-dom/-/react-dom-16.0.0.tgz#9cc3079c3dcd70d4c6e01b84aab2a7e34c303f58"
+  dependencies:
+    fbjs "^0.8.16"
+    loose-envify "^1.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.0"
 
-react-measure:
-  version "1.4.2"
-  resolved "https://registry.yarnpkg.com/react-measure/-/react-measure-1.4.2.tgz#c00ca741e159eb6920e915901dca20863f7c9a78"
+react-measure@^2.0.2:
+  version "2.0.2"
+  resolved "https://registry.yarnpkg.com/react-measure/-/react-measure-2.0.2.tgz#072a9a5fafc01dfbadc1fa5fb09fc351037f636c"
   dependencies:
     get-node-dimensions "^1.2.0"
-    resize-observer-polyfill "^1.2.1"
+    prop-types "^15.5.10"
+    resize-observer-polyfill "^1.4.2"
 
 react-motion@^0.5.0:
   version "0.5.0"
@@ -3351,13 +3380,14 @@ react-motion@^0.5.0:
     prop-types "^15.5.8"
     raf "^3.1.0"
 
-react@15.3.2:
-  version "15.3.2"
-  resolved "https://registry.yarnpkg.com/react/-/react-15.3.2.tgz#a7bccd2fee8af126b0317e222c28d1d54528d09e"
+react@^16.0.0:
+  version "16.0.0"
+  resolved "https://registry.yarnpkg.com/react/-/react-16.0.0.tgz#ce7df8f1941b036f02b2cca9dbd0cb1f0e855e2d"
   dependencies:
-    fbjs "^0.8.4"
+    fbjs "^0.8.16"
     loose-envify "^1.1.0"
-    object-assign "^4.1.0"
+    object-assign "^4.1.1"
+    prop-types "^15.6.0"
 
 read-pkg-up@^1.0.1:
   version "1.0.1"
@@ -3517,9 +3547,9 @@ requires-port@1.0.x, requires-port@1.x.x:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/requires-port/-/requires-port-1.0.0.tgz#925d2601d39ac485e091cf0da5c6e694dc3dcaff"
 
-resize-observer-polyfill@^1.2.1:
-  version "1.2.1"
-  resolved "https://registry.yarnpkg.com/resize-observer-polyfill/-/resize-observer-polyfill-1.2.1.tgz#55a4ff3e4f212a76470835fb7590dbb62a3e6542"
+resize-observer-polyfill@^1.4.2:
+  version "1.4.2"
+  resolved "https://registry.yarnpkg.com/resize-observer-polyfill/-/resize-observer-polyfill-1.4.2.tgz#a37198e6209e888acb1532a9968e06d38b6788e5"
 
 right-align@^0.1.1:
   version "0.1.3"
@@ -3560,6 +3590,10 @@ sass-loader@^4.0.2:
 sax@~1.2.1:
   version "1.2.1"
   resolved "https://registry.yarnpkg.com/sax/-/sax-1.2.1.tgz#7b8e656190b228e81a66aea748480d828cd2d37a"
+
+scroll-into-view@^1.7.3:
+  version "1.9.1"
+  resolved "https://registry.yarnpkg.com/scroll-into-view/-/scroll-into-view-1.9.1.tgz#90c3b338422f9fddaebad90e6954790940dc9c1e"
 
 "semver@2 || 3 || 4 || 5", "semver@2.x || 3.x || 4 || 5", semver@~5.3.0:
   version "5.3.0"
@@ -3817,9 +3851,9 @@ svgo@^0.7.0:
     sax "~1.2.1"
     whet.extend "~0.9.9"
 
-tabbable@^1.0.3:
-  version "1.0.4"
-  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-1.0.4.tgz#70b07e052a05584fb17aa9f1808f51af3ae8d63d"
+tabbable@^1.0.0:
+  version "1.1.0"
+  resolved "https://registry.yarnpkg.com/tabbable/-/tabbable-1.1.0.tgz#2c9a9c9f09db5bb0659f587d532548dd6ef2067b"
 
 tapable@^0.1.8, tapable@~0.1.8:
   version "0.1.10"
@@ -3845,10 +3879,6 @@ tar@^2.0.0, tar@~2.2.1:
     block-stream "*"
     fstream "^1.0.2"
     inherits "2"
-
-teeny-tap@^0.2.0:
-  version "0.2.0"
-  resolved "https://registry.yarnpkg.com/teeny-tap/-/teeny-tap-0.2.0.tgz#167e645182d06ac222d62bb2ab67947a70a58a68"
 
 timers-browserify@^1.0.1:
   version "1.4.2"
@@ -3930,9 +3960,23 @@ uniqs@^2.0.0:
   version "2.0.0"
   resolved "https://registry.yarnpkg.com/uniqs/-/uniqs-2.0.0.tgz#ffede4b36b25290696e6e165d4a59edb998e6b02"
 
+unique-number@^2.0.1:
+  version "2.0.1"
+  resolved "https://registry.yarnpkg.com/unique-number/-/unique-number-2.0.1.tgz#3ff836e92ea076a417e0de5dee1888c86cd86318"
+
 unpipe@~1.0.0:
   version "1.0.0"
   resolved "https://registry.yarnpkg.com/unpipe/-/unpipe-1.0.0.tgz#b2bf4ee8514aae6165b4817829d21b2ef49904ec"
+
+upper-case-first@^1.1.2:
+  version "1.1.2"
+  resolved "https://registry.yarnpkg.com/upper-case-first/-/upper-case-first-1.1.2.tgz#5d79bedcff14419518fd2edb0a0507c9b6859115"
+  dependencies:
+    upper-case "^1.1.1"
+
+upper-case@^1.1.1:
+  version "1.1.3"
+  resolved "https://registry.yarnpkg.com/upper-case/-/upper-case-1.1.3.tgz#f6b4501c2ec4cdd26ba78be7222961de77621598"
 
 url-join@^1.0.0:
   version "1.1.0"


### PR DESCRIPTION
This code is working for me now in one of my own projects that uses React v16, but the included example app does not run because [React ARIA](https://github.com/souporserious/react-aria) is still incompatible with React v16.